### PR TITLE
Thymeleafを導入し、画面に生徒情報を表示。studentsテーブルに2つのカラムを追加

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,13 @@ repositories {
 }
 
 dependencies {
+    //Spring Boot
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    // Thymeleaf
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     //便利機能、ユーティリティ
     implementation 'org.apache.commons:commons-lang3:3.17.0'
-    
+
     //Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/raisetech/studentmanagement/controller/StudentController.java
+++ b/src/main/java/raisetech/studentmanagement/controller/StudentController.java
@@ -2,16 +2,17 @@ package raisetech.studentmanagement.controller;
 
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 import raisetech.studentmanagement.controller.converter.StudentConverter;
 import raisetech.studentmanagement.data.Student;
 import raisetech.studentmanagement.data.StudentCourse;
 import raisetech.studentmanagement.domain.StudentDetail;
 import raisetech.studentmanagement.service.StudentService;
 
-@RestController
+@Controller//@RestControllerから変更
 public class StudentController {
 
   private final StudentService service;
@@ -23,11 +24,24 @@ public class StudentController {
     this.converter = converter;
   }
 
+  //URLパス"/students"にアクセスした際に、このメソッドが呼び出される
   @GetMapping("/students")
-  public List<Student> getStudents(
-      @RequestParam(required = false) Integer minAge,
-      @RequestParam(required = false) Integer maxAge) {
-    return service.getStudents(minAge, maxAge);
+
+  //戻り値の型はStringで、ビューの名前を返す
+  //Model型のパラメータ(呼び出し元が値を定義する特殊な変数)modelを受け取る。これにデータを設定すると、ビューに渡すことができる
+  public String getStudents(Model model) {
+
+    //すべての生徒情報とコース情報を取得
+    List<Student> students = service.getStudents(null, null);
+    List<StudentCourse> studentsCourses = service.getCourses(null);
+
+    //studentLst.htmlの<tr th:each="studentDetail : ${students}">のstudentsに値をセット
+    //modelに"students"という名前で、converter.convertStudentDetails()の戻り値を設定する
+    //converter.convertStudentDetails()は、生徒情報とコース情報をもとに、StudentDetailクラスのリストを作成する
+    model.addAttribute("students", converter.convertStudentDetails(students, studentsCourses));
+
+    //ビューの名前を返す。テンプレートファイルの名前が"studentList.html"であることを示している
+    return "studentList";
   }
 
   @GetMapping("/courses")

--- a/src/main/java/raisetech/studentmanagement/data/Student.java
+++ b/src/main/java/raisetech/studentmanagement/data/Student.java
@@ -11,10 +11,12 @@ public class Student {
   private String fullName;
   private String furiganaName;
   private String nickName;
+  private String phoneNumber;
   private String mailAddress;
   private String municipalityName;
   private int age;
   private String sex;
+  private String occupation;
   private String remark;
   private boolean isDeleted;
 }

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<html lang=ja>
+<head>
+  <meta charset="UTF-8">
+  <title>受講生一覧</title>
+</head>
+<body>
+<h1>受講生一覧</h1>
+<table border="1">
+  <thead>
+  <tr>
+    <th>受講生ID</th>
+    <th>名前 (フルネーム)</th>
+    <th>ふりがな</th>
+    <th>ニックネーム</th>
+    <th>電話番号</th>
+    <th>メールアドレス</th>
+    <th>住んでいる地域 (市区町村)</th>
+    <th>年齢</th>
+    <th>性別</th>
+    <th>職業</th>
+    <th>備考</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr th:each="studentDetail : ${students}">
+    <td th:text="${studentDetail.student.studentId}">10</td>
+    <td th:text="${studentDetail.student.fullName}">山田太郎</td>
+    <td th:text="${studentDetail.student.furiganaName}">やまだ たろう</td>
+    <td th:text="${studentDetail.student.nickName}">Taro</td>
+    <td th:text="${studentDetail.student.phoneNumber}">090-1122-3344</td>
+    <td th:text="${studentDetail.student.mailAddress}">taro.yamada@example.com</td>
+    <td th:text="${studentDetail.student.municipalityName}">東京都新宿区</td>
+    <td th:text="${studentDetail.student.age}">30</td>
+    <td th:text="${studentDetail.student.sex}">male</td>
+    <td th:text="${studentDetail.student.occupation}">学生</td>
+    <td th:text="${studentDetail.student.remark}"> 将来はフリーランスとして働くことを希望</td>
+  </tr>
+  </tbody>
+</table>
+</body>
+</html>


### PR DESCRIPTION
## 概要

第27回(Thymeleafを使ったReadの画面描画処理)の課題を行いました。

**課題**
・Thymeleafを使って、受講生一覧を画面表示させること。

・できれば、受講生情報のテーブルにカラムを追加して、カスタマイズしてみること。
→　phone_number(電話番号)とoccupation (職業)という2つのカラムを追加してみました。

ご確認よろしくお願いいたします！

## 動作確認
![スクリーンショット 2024-11-06 001156](https://github.com/user-attachments/assets/869d6692-e7f7-4925-84d6-6d6d1e5b56ff)

変更前のテーブル
![スクリーンショット 2024-11-05 225658](https://github.com/user-attachments/assets/a75c533a-f39b-4fcd-9a21-2f6ec1191d2b)

変更後のテーブル
![スクリーンショット 2024-11-06 000301](https://github.com/user-attachments/assets/bbaaf9d2-f7d7-4cc0-8394-6ea1bef249c5)
