### PR TITLE
受講生情報の更新機能を実装

### DIFF
--- a/src/main/java/raisetech/studentmanagement/controller/GlobalExceptionHandler.java
+++ b/src/main/java/raisetech/studentmanagement/controller/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package raisetech.studentmanagement.controller;
+
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import raisetech.studentmanagement.exception.StudentNotFoundException;
+
+// アプリケーション全体の例外を処理するためのクラスであることを示す
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+  // StudentNotFoundExceptionが発生した場合に呼び出されるメソッド
+  @ExceptionHandler(StudentNotFoundException.class)
+
+  // 例外から取得したエラーメッセージをモデルに追加し、ビュー(HTML)で表示できるようにする
+  public String handleStudentNotFoundException(StudentNotFoundException ex, Model model) {
+    model.addAttribute("errorMessage", ex.getMessage());
+    // エラー画面のテンプレート名
+    return "error";
+  }
+}

--- a/src/main/java/raisetech/studentmanagement/controller/StudentController.java
+++ b/src/main/java/raisetech/studentmanagement/controller/StudentController.java
@@ -8,6 +8,7 @@ import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -60,11 +61,12 @@ public class StudentController {
     List<StudentCourse> studentsCourses = service.getCourses(null);
 
     //studentList.htmlの<tr th:each="studentDetail : ${students}">のstudentsに値をセット
-    //modelに"students"という名前で、converter.convertStudentDetails()の戻り値を設定する
+    //modelに"studentDetail"という名前で、converter.convertStudentDetails()の戻り値を設定する
     //List<StudentDetail>型のconverter.convertStudentDetails()は、生徒情報とコース情報をもとに、StudentDetailクラスのリストを作成する
     //addAttribute()は、Thymeleafのテンプレートに表示したいデータを渡すために使うもの
     //第一引数は、テンプレートでデータにアクセスするためのキー、第二引数は、テンプレートに表示する実際のデータを指定する
-    model.addAttribute("students", converter.convertStudentDetails(students, studentsCourses));
+    model.addAttribute("studentDetailList",
+        converter.convertStudentDetails(students, studentsCourses));
 
     //ビューの名前を返す。テンプレートファイルの名前が"studentList.html"であることを示している
     return "studentList";
@@ -104,6 +106,7 @@ public class StudentController {
   @GetMapping("/newStudents")
 
   //Webアプリの画面に表示するデータを準備し、テンプレート名を返すメソッド。引数のModelオブジェクトは、テンプレートにデータを渡すためのもの
+  //Controllerがデータを準備する
   public String newStudents(Model model) {
 
     StudentDetail studentDetail = new StudentDetail();
@@ -116,6 +119,7 @@ public class StudentController {
     //model.addAttributeは、テンプレート（ビュー）にデータを渡すためのメソッド
     //空のStudentDetailオブジェクトをテンプレートに渡し、フォームの初期値として使う
     //テンプレートでは、studentDetail.student.fullNameのようにして、StudentDetailオブジェクトのフィールドにアクセスできる
+    //データにstudentDetailという名前をつけてモデルに追加
     model.addAttribute("studentDetail", studentDetail);
 
     //registerStudent.htmlテンプレートを表示するための名前を返す。この名前は、テンプレートファイルの名前と一致している
@@ -139,6 +143,45 @@ public class StudentController {
     //新規受講生を登録する処理を実装する
     //サービス層のregisterStudentメソッドを呼び出し、studentDetailから取り出した学生情報を登録する
     service.registerStudent(studentDetail);
+
+    //学生が登録された後、一覧画面（/students）にリダイレクトして確認できるようにするn
+    return "redirect:/students";
+  }
+
+  @GetMapping("/updateStudents/{studentId}")
+
+  //Webアプリの画面に表示するデータを準備し、テンプレート名を返すメソッド。引数のModelオブジェクトは、テンプレートにデータを渡すためのもの
+  public String getStudentDetailById(@PathVariable String studentId, Model model) {
+
+    // Serviceクラスのメソッドを呼び出して既存データを取得
+    StudentDetail studentDetail = service.getStudentDetailById(studentId);
+
+    //model.addAttributeは、テンプレート（ビュー）にデータを渡すためのメソッド
+    //テンプレートでは、studentDetail.student.fullNameのようにして、StudentDetailオブジェクトのフィールドにアクセスできる
+    //データにstudentDetailという名前をつけてモデルに追加
+    model.addAttribute("studentDetail", studentDetail);
+
+    //updateStudent.htmlテンプレートを表示するための名前を返す。この名前は、テンプレートファイルの名前と一致している
+    return "updateStudent";
+  }
+
+  @PostMapping("/updateStudents")
+
+  //Thymeleafを使うときは確実に行うもの
+  //@ModelAttributeアノテーションを使って、フォームから送信されたStudentDetailのデータを受け取る
+  //BindingResultは、入力チェックの結果を受け取るためのもの
+  //入力チェックしたいものをBindingResultに入れて、エラーが発生したら、元の画面に戻す
+  //ユーザーがフォームに無効なデータを入力した場合（必須項目の未入力、形式エラーなど）を検出
+  //バリデーション機能を追加した際に機能するように準備
+  public String updateStudentDetail(@ModelAttribute StudentDetail studentDetail,
+      BindingResult result) {
+    if (result.hasErrors()) {
+      return "updateStudent";
+    }
+
+    //新規受講生を登録する処理を実装する
+    //サービス層のregisterStudentメソッドを呼び出し、studentDetailから取り出した学生情報を登録する
+    service.updateStudentDetail(studentDetail);
 
     //学生が登録された後、一覧画面（/students）にリダイレクトして確認できるようにする
     return "redirect:/students";

--- a/src/main/java/raisetech/studentmanagement/controller/StudentController.java
+++ b/src/main/java/raisetech/studentmanagement/controller/StudentController.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import raisetech.studentmanagement.controller.converter.StudentConverter;
+import raisetech.studentmanagement.data.CourseType;
 import raisetech.studentmanagement.data.Student;
 import raisetech.studentmanagement.data.StudentCourse;
 import raisetech.studentmanagement.domain.StudentDetail;
@@ -132,6 +134,12 @@ public class StudentController {
     //データにstudentDetailという名前をつけてモデルに追加
     model.addAttribute("studentDetail", studentDetail);
 
+    // UNKNOWNを除いたCourseTypeの一覧をモデルに追加
+    model.addAttribute("courseTypes",
+        Arrays.stream(CourseType.values())
+            .filter(type -> type != CourseType.UNKNOWN)
+            .collect(Collectors.toList()));
+
     //registerStudent.htmlテンプレートを表示するための名前を返す。この名前は、テンプレートファイルの名前と一致している
     return "registerStudent";
   }
@@ -211,6 +219,19 @@ public class StudentController {
 
     // HTMLでdates['startDate0']のように参照できるようにモデルに追加
     model.addAttribute("dates", dates);
+
+    // UNKNOWNを除いたCourseTypeの一覧をモデルに追加
+    // "courseTypes"という名前で結果をHTMLテンプレートに渡す
+    model.addAttribute("courseTypes",
+
+        // CourseType.values()でEnum定数の配列を取得し、Streamに変換
+        Arrays.stream(CourseType.values())
+
+            // UNKNOWN定数だけを除外する
+            .filter(type -> type != CourseType.UNKNOWN)
+
+            // StreamをListに変換して結果を返す
+            .collect(Collectors.toList()));
 
     //updateStudent.htmlテンプレートを表示するための名前を返す。この名前は、テンプレートファイルの名前と一致している
     return "updateStudent";

--- a/src/main/java/raisetech/studentmanagement/controller/StudentController.java
+++ b/src/main/java/raisetech/studentmanagement/controller/StudentController.java
@@ -108,7 +108,7 @@ public class StudentController {
     return converter.convertStudentDetails(students, studentCourses);
   }
 
-  @GetMapping("/newStudents")
+  @GetMapping("/students/new")
 
   //Webアプリの画面に表示するデータを準備し、テンプレート名を返すメソッド。引数のModelオブジェクトは、テンプレートにデータを渡すためのもの
   //Controllerがデータを準備する
@@ -172,7 +172,7 @@ public class StudentController {
     return "redirect:/students";
   }
 
-  @GetMapping("/updateStudents/{studentId}")
+  @GetMapping("/students/{studentId}")
 
   //Webアプリの画面に表示するデータを準備し、テンプレート名を返すメソッド。引数のModelオブジェクトは、テンプレートにデータを渡すためのもの
   public String getStudentDetailById(@PathVariable String studentId, Model model) {

--- a/src/main/java/raisetech/studentmanagement/data/CourseType.java
+++ b/src/main/java/raisetech/studentmanagement/data/CourseType.java
@@ -1,0 +1,46 @@
+package raisetech.studentmanagement.data;
+
+// Enumを定義（列挙型）。固定されたコース情報を管理するためのクラス
+public enum CourseType {
+
+  // 各コースの定数定義。引数は(コース名, コースID)の順
+  JAVA_FULL("Javaフルコース", "A001"),
+  AWS_FULL("AWSフルコース", "A002"),
+  WORDPRESS("WordPress副業コース", "A003"),
+  DESIGN("デザインコース", "A004"),
+  WEB_MARKETING("Webマーケティングコース", "A005"),
+  UNKNOWN("", "A999"); // 未知のコースの場合
+
+  private final String courseName;
+  private final String courseId;
+
+  CourseType(String courseName, String courseId) {
+    this.courseName = courseName;
+    this.courseId = courseId;
+  }
+
+  public String getCourseName() {
+    return courseName;
+  }
+
+  public String getCourseId() {
+    return courseId;
+  }
+
+  // コース名からCourseTypeを探すクラスメソッド
+  public static CourseType fromCourseName(String courseName) {
+
+    // CourseType.values()で全てのEnum定数(JAVA_FULL, AWS_FULL, WORDPRESS...)の配列を取得し、順番に処理
+    for (CourseType type : CourseType.values()) {
+
+      // 現在処理中のEnum定数のコース名(type.getCourseName())が、引数で渡されたコース名と完全に一致するか確認
+      if (type.getCourseName().equals(courseName)) {
+
+        // コース名が一致したEnum定数が見つかったら、そのEnum定数(JAVA_FULLなど)をそのまま返す
+        return type;
+      }
+    }
+    // forループを最後まで処理しても一致するEnum定数が見つからなかった場合、UNKNOWN定数を返す
+    return UNKNOWN;
+  }
+}

--- a/src/main/java/raisetech/studentmanagement/data/StudentCourse.java
+++ b/src/main/java/raisetech/studentmanagement/data/StudentCourse.java
@@ -13,4 +13,20 @@ public class StudentCourse {
   private String courseName;
   private LocalDate courseStartDate;
   private LocalDate courseExpectedEndDate;
+
+  public String getCourseStartDateFormatted() {
+
+    // nullのときに空文字列を返し、そうでないときに日付を文字列形式で返す
+    if (courseStartDate == null) {
+      return "";
+    }
+    return courseStartDate.toString();
+  }
+
+  public String getCourseExpectedEndDateFormatted() {
+    if (courseExpectedEndDate == null) {
+      return "";
+    }
+    return courseExpectedEndDate.toString();
+  }
 }

--- a/src/main/java/raisetech/studentmanagement/exception/StudentNotFoundException.java
+++ b/src/main/java/raisetech/studentmanagement/exception/StudentNotFoundException.java
@@ -1,0 +1,14 @@
+package raisetech.studentmanagement.exception;
+
+// 受講生が見つからない場合に発生させる例外クラス
+// RuntimeExceptionとは、プログラム実行中に発生する可能性があるエラーの基本クラス
+// これを継承することで、try-catchで囲む必要がなくなり、コードがすっきりする
+public class StudentNotFoundException extends RuntimeException {
+
+  // コンストラクタ - 受講生IDを受け取ってエラーメッセージを作る
+  public StudentNotFoundException(String studentId) {
+
+    // 親クラス(RuntimeException)のコンストラクタを呼び出し、エラーメッセージを設定
+    super("受講生ID: " + studentId + " が見つかりません");
+  }
+}

--- a/src/main/java/raisetech/studentmanagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/studentmanagement/repository/StudentRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 import raisetech.studentmanagement.data.Student;
 import raisetech.studentmanagement.data.StudentCourse;
 
@@ -18,11 +19,22 @@ public interface StudentRepository {
 
   //@Selectアノテーションは、このメソッドがSQLのSELECT文を実行することを指定
   //"SELECT * FROM students" は、students テーブルからすべての列と行を取得するSQLクエリ
+  //引数なしで呼び出され、すべての学生データをStudentオブジェクトのリストとして返す
   @Select("SELECT * FROM students")
   List<Student> searchStudents();
 
   @Select("SELECT * FROM students_courses")
   List<StudentCourse> searchCourses();
+
+  // 受講生のIDを指定して、1人の学生データを取得
+  // students テーブルから、student_id が指定された値と一致するレコードを取得する
+  // #{studentId} の部分は、メソッドの引数 studentId の値が埋め込まれる
+  @Select("SELECT * FROM students WHERE student_id = #{studentId}")
+  Student findById(String studentId);
+
+  // 受講生のIDを指定して、すべてのコース情報を取得
+  @Select("SELECT * FROM students_courses WHERE student_id = #{studentId}")
+  List<StudentCourse> findCourseById(String studentId);
 
   // @Insertアノテーションは、このメソッドがSQLのINSERT文を実行することを指定
   // 目的：Javaオブジェクトの値をSQL文に埋め込んでデータベースに保存する
@@ -44,8 +56,16 @@ public interface StudentRepository {
       // 目的：StudentCourseオブジェクトの各フィールドをデータベースの適切なカラムに対応させる
       "INSERT INTO students_courses(course_id, student_id, course_name, course_start_date, course_expected_end_date)"
           + "VALUES (#{courseId}, #{studentId}, #{courseName}, #{courseStartDate}, #{courseExpectedEndDate})")
-      
+
     // コース情報保存用メソッドのインターフェース宣言
     // 目的：MyBatisがこのメソッド呼び出しを上記のSQL実行に変換する
   void saveStudentCourse(StudentCourse studentCourse);
+
+  @Update(
+      "UPDATE students SET full_name = #{fullName}, furigana_name = #{furiganaName}, nick_name = #{nickName}, phone_number = #{phoneNumber}, mail_address = #{mailAddress}, municipality_name = #{municipalityName}, age = #{age}, sex = #{sex}, occupation = #{occupation}, remark = #{remark} WHERE student_id = #{studentId}")
+  void updateStudent(Student student);
+
+  @Update(
+      "UPDATE students_courses SET course_name = #{courseName}, course_start_date = #{courseStartDate}, course_expected_end_date = #{courseExpectedEndDate} WHERE course_id = #{courseId}")
+  void updateStudentCourse(StudentCourse studentCourse);
 }

--- a/src/main/java/raisetech/studentmanagement/service/StudentService.java
+++ b/src/main/java/raisetech/studentmanagement/service/StudentService.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import raisetech.studentmanagement.data.CourseType;
 import raisetech.studentmanagement.data.Student;
 import raisetech.studentmanagement.data.StudentCourse;
 import raisetech.studentmanagement.domain.StudentDetail;
@@ -105,23 +106,12 @@ public class StudentService {
     }
   }
 
-  // コース名に基づいた固定IDを取得するメソッドを追加
+  // コース名に基づいて固定IDを取得するメソッド
   private String getCommonCourseId(String courseName) {
-    // コース名に基づいて固定IDを返す
-    switch (courseName) {
-      case "Javaフルコース":
-        return "A001";
-      case "AWSフルコース":
-        return "A002";
-      case "WordPress副業コース":
-        return "A003";
-      case "デザインコース":
-        return "A004";
-      case "Webマーケティングコース":
-        return "A005";
-      default:
-        return "A999"; // 未知のコースの場合
-    }
+
+    // CourseTypeクラスのfromCourseNameメソッドを使い、コース名からCourseType定数(Enum（列挙型）定数)を取得
+    // さらにgetCourseIdメソッドで、その定数のコースIDを取得して返す
+    return CourseType.fromCourseName(courseName).getCourseId();
   }
 
   @Transactional

--- a/src/main/java/raisetech/studentmanagement/service/StudentService.java
+++ b/src/main/java/raisetech/studentmanagement/service/StudentService.java
@@ -11,6 +11,7 @@ import raisetech.studentmanagement.data.CourseType;
 import raisetech.studentmanagement.data.Student;
 import raisetech.studentmanagement.data.StudentCourse;
 import raisetech.studentmanagement.domain.StudentDetail;
+import raisetech.studentmanagement.exception.StudentNotFoundException;
 import raisetech.studentmanagement.repository.StudentRepository;
 
 //ビジネスロジックを記述するクラスには@Serviceアノテーションを付与。そのクラスはBean化され、内部メモリ上に格納される
@@ -145,7 +146,13 @@ public class StudentService {
     // 特定のIDを持つ受講生情報を取得
     Student student = repository.findById(studentId);
 
-    // その学生が受講しているコース情報を取得
+    // 該当する受講生が見つからない場合の処理
+    if (student == null) {
+      // StudentNotFoundExceptionをスローして処理を中断し、エラー処理に移る
+      throw new StudentNotFoundException(studentId);
+    }
+
+    // 受講生が受講しているコース情報を取得
     List<StudentCourse> courses = repository.findCourseById(studentId);
 
     // 受講生情報とコース情報を組み合わせてStudentDetailを作成

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>エラー</title>
+</head>
+<body>
+<h1>エラーが発生しました</h1>
+<p th:text="${errorMessage}">エラーメッセージ</p>
+<a th:href="@{/students}">受講生一覧に戻る</a>
+</body>
+</html>

--- a/src/main/resources/templates/registerStudent.html
+++ b/src/main/resources/templates/registerStudent.html
@@ -107,7 +107,44 @@ method="post"： フォームのデータがPOSTメソッドを使ってサー�
       <option value="WordPress副業コース">WordPress副業コース</option>
       <option value="デザインコース">デザインコース</option>
     </select>
+
+    <div>
+      <!--/*-->
+      ラベル要素を作成し、「コース開始日:」というテキストを表示する
+      th:for属性は、このラベルがどの入力欄と関連付けられているかを指定する
+      'courseStartDate' + ${stat.index}は、各コース（1番目、2番目...）ごとに違う名前をつける
+      例えば1番目のコースなら「courseStartDate0」、2番目なら「courseStartDate1」となる
+      <!--*/-->
+      <label th:for="'courseStartDate' + ${stat.index}">コース開始日:</label>
+
+      <!--/*-->
+      日付入力フィールドを作成する
+      type="date"は、ブラウザに日付選択用のカレンダーを表示させる
+      th:idは、このフィールドの名前を設定する（ラベルのfor属性と同じ名前にする）
+      th:fieldは、この入力欄に入力された値をどこに保存するかを指定する
+      studentsCourses[__${stat.index}__]の部分は、今処理している順番のコースを指している
+      __${stat.index}__の部分は、Thymeleafが数字として評価するための特殊な書き方
+      例えば1番目のコースなら「studentsCourses[0]」、2番目なら「studentsCourses[1]」となる
+      requiredは、この項目が必須であることを示す
+      <!--*/-->
+      <input type="date" th:id="'courseStartDate' + ${stat.index}"
+             th:field="*{studentsCourses[__${stat.index}__].courseStartDate}" required/>
+
+      <!--/*-->
+      小さいテキストで説明文を表示する
+      ユーザーが何も入力しなかった場合の動作を教えている
+      <!--*/-->
+      <small>（未入力の場合、今日の日付が設定されます）</small>
+    </div>
+
+    <div>
+      <label th:for="'courseExpectedEndDate' + ${stat.index}">コース終了予定日:</label>
+      <input type="date" th:id="'courseExpectedEndDate' + ${stat.index}"
+             th:field="*{studentsCourses[__${stat.index}__].courseExpectedEndDate}" readonly/>
+      <small>（コース開始日の1年後に自動設定されます）</small>
+    </div>
   </div>
+
   <!--/*-->
   submitにしておくと、更新ボタンを押したときに/updateStudentsに対して、データを送信することができる
   余白を追加

--- a/src/main/resources/templates/registerStudent.html
+++ b/src/main/resources/templates/registerStudent.html
@@ -99,15 +99,20 @@ method="post"： フォームのデータがPOSTメソッドを使ってサー�
            th:for="studentCourse.__${stat.index}__.courseName">受講コース名:</label>
     <select th:id="studentCourse.__${stat.index}__.courseName"
             th:field="*{studentsCourses[__${stat.index}__].courseName}" required>
-      <!-- 選択肢を追加 -->
-      <option value="">コースを選択してください</option>
-      <option value="AWSフルコース">AWSフルコース</option>
-      <option value="Javaフルコース">Javaフルコース</option>
-      <option value="Webマーケティングコース">Webマーケティングコース</option>
-      <option value="WordPress副業コース">WordPress副業コース</option>
-      <option value="デザインコース">デザインコース</option>
-    </select>
 
+      <!--/*-->
+      コース選択のドロップダウンメニューを動的に生成
+      - CourseTypeのEnumからコース一覧を自動生成
+      - コースが増減してもHTMLの修正が不要になる
+      CourseTypeの各要素に対してループ処理を行い、それぞれに対してoptionタグを生成する
+      各optionタグのvalue属性に、CourseTypeの日本語名（例：Javaフルコース）を設定する
+      各optionタグの表示テキストに、CourseTypeの日本語名を設定する
+      <!--*/-->
+      <option th:each="courseType : ${courseTypes}"
+              th:value="${courseType.courseName}"
+              th:text="${courseType.courseName}">コース名
+      </option>
+    </select>
     <div>
       <!--/*-->
       ラベル要素を作成し、「コース開始日:」というテキストを表示する

--- a/src/main/resources/templates/registerStudent.html
+++ b/src/main/resources/templates/registerStudent.html
@@ -134,12 +134,6 @@ method="post"： フォームのデータがPOSTメソッドを使ってサー�
       <!--*/-->
       <input type="date" th:id="'courseStartDate' + ${stat.index}"
              th:field="*{studentsCourses[__${stat.index}__].courseStartDate}" required/>
-
-      <!--/*-->
-      小さいテキストで説明文を表示する
-      ユーザーが何も入力しなかった場合の動作を教えている
-      <!--*/-->
-      <small>（未入力の場合、今日の日付が設定されます）</small>
     </div>
 
     <div>

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -15,7 +15,7 @@
     <th>ニックネーム</th>
     <th>電話番号</th>
     <th>メールアドレス</th>
-    <th>住んでいる地域 (市区町村)</th>
+    <th>住んでいる地域 (都道府県市区町村)</th>
     <th>年齢</th>
     <th>性別</th>
     <th>職業</th>
@@ -42,7 +42,6 @@
       <a th:href="@{/updateStudents/{id}(id=${studentDetail.student.studentId})}"
          th:text="${studentDetail.student.fullName}"></a>
     </td>
-    <td th:text="${studentDetail.student.fullName}">山田太郎</td>
     <td th:text="${studentDetail.student.furiganaName}">やまだ たろう</td>
     <td th:text="${studentDetail.student.nickName}">Taro</td>
     <td th:text="${studentDetail.student.phoneNumber}">090-1122-3344</td>

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -23,8 +23,25 @@
   </tr>
   </thead>
   <tbody>
-  <tr th:each="studentDetail : ${students}">
+  <!--/*-->
+  HTMLがデータを表示する
+  studentDetailListという名前のデータを1つずつ取り出して、変数studentDetailに入れる
+  ${studentDetailList}リストの各要素はStudentDetail型のオブジェクト
+  studentDetail は StudentDetail 型のオブジェクトを一時的に保存するための変数名
+  <!--*/-->
+  <tr th:each="studentDetail : ${studentDetailList}">
     <td th:text="${studentDetail.student.studentId}">10</td>
+    <td>
+      <!--/*-->
+      受講生一覧画面で各受講生の名前をクリック可能にし、そのリンク先を更新画面（/updateStudents/{id}）に設定
+      th:href - Thymeleafでリンクを動的に生成するための属性
+      @{/updateStudents/{id}(id=${studentDetail.student.studentId})} - URLテンプレートで、{id}
+      の部分に実際のIDが入る
+      th:text - リンクのテキスト部分を動的に設定するための属性
+      <!--*/-->
+      <a th:href="@{/updateStudents/{id}(id=${studentDetail.student.studentId})}"
+         th:text="${studentDetail.student.fullName}"></a>
+    </td>
     <td th:text="${studentDetail.student.fullName}">山田太郎</td>
     <td th:text="${studentDetail.student.furiganaName}">やまだ たろう</td>
     <td th:text="${studentDetail.student.nickName}">Taro</td>

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -33,13 +33,13 @@
     <td th:text="${studentDetail.student.studentId}">10</td>
     <td>
       <!--/*-->
-      受講生一覧画面で各受講生の名前をクリック可能にし、そのリンク先を更新画面（/updateStudents/{id}）に設定
+      受講生一覧画面で各受講生の名前をクリック可能にし、そのリンク先を更新画面（/students/{id}）に設定
       th:href - Thymeleafでリンクを動的に生成するための属性
-      @{/updateStudents/{id}(id=${studentDetail.student.studentId})} - URLテンプレートで、{id}
+      @{/students/{id}(id=${studentDetail.student.studentId})} - URLテンプレートで、{id}
       の部分に実際のIDが入る
       th:text - リンクのテキスト部分を動的に設定するための属性
       <!--*/-->
-      <a th:href="@{/updateStudents/{id}(id=${studentDetail.student.studentId})}"
+      <a th:href="@{/students/{id}(id=${studentDetail.student.studentId})}"
          th:text="${studentDetail.student.fullName}"></a>
     </td>
     <td th:text="${studentDetail.student.furiganaName}">やまだ たろう</td>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -137,12 +137,6 @@ method="post"： フォームのデータがPOSTメソッドを使ってサー�
       <input type="date" th:id="'courseStartDate' + ${stat.index}"
              th:name="'studentsCourses[' + ${stat.index} + '].courseStartDate'"
              th:value="${dates['startDate' + stat.index]}" required/>
-
-      <!--/*-->
-      小さいテキストで説明文を表示する
-      ユーザーが何も入力しなかった場合の動作を教えている
-      <!--*/-->
-      <small>（未入力の場合、今日の日付が設定されます）</small>
     </div>
 
     <div>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -108,15 +108,12 @@ method="post"： フォームのデータがPOSTメソッドを使ってサー�
     <label for="courseName"
            th:for="studentCourse.__${stat.index}__.courseName">受講コース名:</label>
     <select th:id="studentCourse.__${stat.index}__.courseName"
-            th:field="*{studentsCourses[__${stat.index}__].courseName}">
+            th:field="*{studentsCourses[__${stat.index}__].courseName}" required>
 
       <!-- 選択肢を追加 -->
-      <option value="">コースを選択してください</option>
-      <option value="AWSフルコース">AWSフルコース</option>
-      <option value="Javaフルコース">Javaフルコース</option>
-      <option value="Webマーケティングコース">Webマーケティングコース</option>
-      <option value="WordPress副業コース">WordPress副業コース</option>
-      <option value="デザインコース">デザインコース</option>
+      <option th:each="courseType : ${courseTypes}"
+              th:value="${courseType.courseName}"
+              th:text="${courseType.courseName}">コース名</option>
     </select>
 
     <div>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -2,18 +2,24 @@
 <html xmlns:th="http://www.thymeleaf.org" lang="ja">
 <head>
   <meta charset="UTF-8">
-  <title>受講生登録</title>
+  <title>受講生更新</title>
 </head>
 <body>
-<h1>受講生登録</h1>
+<h1>受講生更新</h1>
 <!--/*-->
-/registerStudentsは表示するときのURLではなく、POSTするときのURL
-th:action="@{/registerStudents}"： フォームの送信先URL（/registerStudents）を指定
+/updateStudentsは表示するときのURLではなく、POSTするときのURL
+th:action="@{/updateStudents}"： フォームの送信先URL（/updateStudents）を指定
 th:object="${studentDetail}"： フォームの入力データがstudentDetailというインスタンスに保存されることを意味
 フォームに入力された内容は、このインスタンスのプロパティ（nameやage）に自動的にセットされる
 method="post"： フォームのデータがPOSTメソッドを使ってサーバーに送信されることを指定
 <!--*/-->
-<form th:action="@{/registerStudents}" th:object="${studentDetail}" method="post">
+<form th:action="@{/updateStudents}" th:object="${studentDetail}" method="post">
+
+  <!--/*-->
+  student.studentId を隠しフィールドとして追加
+  隠しフィールド（hidden field）とは、ユーザーには表示されないが、フォーム送信時にデータを送るためのHTMLの入力要素
+  <!--*/-->
+  <input type="hidden" th:field="*{student.studentId}"/>
 
   <!--/*-->
   HTMLのタグで、囲んだ部分をブロック要素としてグループ化するためのタグ
@@ -95,10 +101,15 @@ method="post"： フォームのデータがPOSTメソッドを使ってサー�
   </div>
 
   <div th:each="course, stat : *{studentsCourses}">
+
+    <!-- コースIDを隠しフィールドとして追加 -->
+    <input type="hidden" th:field="*{studentsCourses[__${stat.index}__].courseId}"/>
+    <input type="hidden" th:field="*{studentsCourses[__${stat.index}__].studentId}"/>
     <label for="courseName"
            th:for="studentCourse.__${stat.index}__.courseName">受講コース名:</label>
     <select th:id="studentCourse.__${stat.index}__.courseName"
-            th:field="*{studentsCourses[__${stat.index}__].courseName}" required>
+            th:field="*{studentsCourses[__${stat.index}__].courseName}">
+
       <!-- 選択肢を追加 -->
       <option value="">コースを選択してください</option>
       <option value="AWSフルコース">AWSフルコース</option>
@@ -108,12 +119,13 @@ method="post"： フォームのデータがPOSTメソッドを使ってサー�
       <option value="デザインコース">デザインコース</option>
     </select>
   </div>
+  
   <!--/*-->
   submitにしておくと、更新ボタンを押したときに/updateStudentsに対して、データを送信することができる
   余白を追加
   <!--*/-->
   <div style="margin-top: 20px;">
-    <button type="submit" style="margin-right: 15px;">登録</button>
+    <button type="submit" style="margin-right: 15px;">更新</button>
     <a th:href="@{/students}">一覧に戻る</a>
   </div>
 </form>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -118,16 +118,52 @@ method="post"： フォームのデータがPOSTメソッドを使ってサー�
       <option value="WordPress副業コース">WordPress副業コース</option>
       <option value="デザインコース">デザインコース</option>
     </select>
-  </div>
-  
-  <!--/*-->
-  submitにしておくと、更新ボタンを押したときに/updateStudentsに対して、データを送信することができる
-  余白を追加
-  <!--*/-->
-  <div style="margin-top: 20px;">
-    <button type="submit" style="margin-right: 15px;">更新</button>
-    <a th:href="@{/students}">一覧に戻る</a>
-  </div>
+
+    <div>
+      <!--/*-->
+      ラベル要素を作成し、「コース開始日:」というテキストを表示する
+      th:for属性は、このラベルがどの入力欄と関連付けられているかを指定する
+      'courseStartDate' + ${stat.index}は、各コース（1番目、2番目...）ごとに違う名前をつける
+      例えば1番目のコースなら「courseStartDate0」、2番目なら「courseStartDate1」となる
+      <!--*/-->
+      <label th:for="'courseStartDate' + ${stat.index}">コース開始日:</label>
+
+      <!--/*-->
+      日付入力フィールドを作成する
+      type="date"は、ブラウザに日付選択用のカレンダーを表示させる
+      th:idは、このフィールドの識別子を設定する（ラベルのfor属性と同じ名前にする）
+      th:nameは、送信時のパラメータ名を指定する
+      th:valueは、入力欄に表示する初期値を設定する
+      dates['startDate' + stat.index]は、コントローラから渡された日付の文字列
+      requiredは、この項目が必須であることを示す
+      <!--*/-->
+      <input type="date" th:id="'courseStartDate' + ${stat.index}"
+             th:name="'studentsCourses[' + ${stat.index} + '].courseStartDate'"
+             th:value="${dates['startDate' + stat.index]}" required/>
+
+      <!--/*-->
+      小さいテキストで説明文を表示する
+      ユーザーが何も入力しなかった場合の動作を教えている
+      <!--*/-->
+      <small>（未入力の場合、今日の日付が設定されます）</small>
+    </div>
+
+    <div>
+      <label th:for="'courseExpectedEndDate' + ${stat.index}">コース終了予定日:</label>
+      <input type="date" th:id="'courseExpectedEndDate' + ${stat.index}"
+             th:name="'studentsCourses[' + ${stat.index} + '].courseExpectedEndDate'"
+             th:value="${dates['endDate' + stat.index]}" readonly/>
+      <small>（コース開始日の1年後に自動設定されます）</small>
+    </div>
+
+    <!--/*-->
+    submitにしておくと、更新ボタンを押したときに/updateStudentsに対して、データを送信することができる
+    余白を追加
+    <!--*/-->
+    <div style="margin-top: 20px;">
+      <button type="submit" style="margin-right: 15px;">登録</button>
+      <a th:href="@{/students}">一覧に戻る</a>
+    </div>
 </form>
 </body>
 </html>


### PR DESCRIPTION
## 概要

第29回(受講生情報登録処理の実装)の課題を行いました。

**課題**
受講生情報の更新処理を実装すること
・受講生情報を更新する画面の作成
・受講生の名前をクリックすると、更新画面を表示できるようにリンクを設定する

その他、前回のPRとの変更点 (主なもの)
・コースIDを固定IDに変更
・日付情報の自動設定機能を追加



ご確認よろしくお願いいたします！

## 動作確認
## **【更新画面】**
![スクリーンショット 2025-03-03 205022](https://github.com/user-attachments/assets/b12fd0f7-4c57-4cab-b2a7-6e8ff434e5cb)


## **【更新前】**
受講生一覧のカラムとデータがずれていますが、修正しています。修正後の画像もあります。
https://github.com/Aka871/student-management/pull/9#issuecomment-2714708592
![スクリーンショット 2025-03-03 204850](https://github.com/user-attachments/assets/a2d2c922-b391-4f34-8c07-fcd0f790741b)
![スクリーンショット 2025-03-03 203351](https://github.com/user-attachments/assets/e43bef6d-46a2-441b-8bb5-70f5c8efb643)



## **【更新後】**
変更可能な、すべての項目を更新しています。

![スクリーンショット 2025-03-03 220058](https://github.com/user-attachments/assets/cd135c17-c318-44ae-a80d-7b8d39cf2cb9)
![スクリーンショット 2025-03-03 222212](https://github.com/user-attachments/assets/ea2c9ec5-3328-4392-b371-c3bf4ceab350)