### PR TITLE
feat: 受講生情報の論理削除機能(delete)を実装

### DIFF
--- a/src/main/java/raisetech/studentmanagement/controller/StudentController.java
+++ b/src/main/java/raisetech/studentmanagement/controller/StudentController.java
@@ -203,11 +203,6 @@ public class StudentController {
       dates.put("startDate" + i, course.getCourseStartDate().toString());
       dates.put("endDate" + i, course.getCourseExpectedEndDate().toString());
 
-      // デバッグログを出力
-      System.out.println("Course: " + course.getCourseName() +
-          " Start: " + course.getCourseStartDate() +
-          " End: " + course.getCourseExpectedEndDate());
-
       // 次のコースのためにカウンターを増やす
       i++;
     }

--- a/src/main/java/raisetech/studentmanagement/controller/StudentController.java
+++ b/src/main/java/raisetech/studentmanagement/controller/StudentController.java
@@ -60,9 +60,9 @@ public class StudentController {
   //Model型のパラメータ(呼び出し元が値を定義する特殊な変数)modelを受け取る。これにデータを設定すると、ビューに渡すことができる
   public String getStudents(Model model) {
 
-    //すべての生徒情報とコース情報を取得(引数がnullのため)
+    //論理削除されていない生徒情報とコース情報を取得(引数がnullのため)
     //List<Student>の中には、Studentクラスのインスタンスが格納されている。変数名は任意で良い
-    List<Student> students = service.getStudents(null, null);
+    List<Student> students = service.getNotDeletedStudents();
     List<StudentCourse> studentsCourses = service.getCourses(null);
 
     //studentList.htmlの<tr th:each="studentDetail : ${students}">のstudentsに値をセット

--- a/src/main/java/raisetech/studentmanagement/data/Student.java
+++ b/src/main/java/raisetech/studentmanagement/data/Student.java
@@ -23,5 +23,7 @@ public class Student {
   private String sex;
   private String occupation;
   private String remark;
+
+  //フィールド名をdeletedにした。thymeleafとの連携問題を解決するため
   private boolean deleted;
 }

--- a/src/main/java/raisetech/studentmanagement/data/Student.java
+++ b/src/main/java/raisetech/studentmanagement/data/Student.java
@@ -23,5 +23,5 @@ public class Student {
   private String sex;
   private String occupation;
   private String remark;
-  private boolean isDeleted;
+  private boolean deleted;
 }

--- a/src/main/java/raisetech/studentmanagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/studentmanagement/repository/StudentRepository.java
@@ -62,7 +62,8 @@ public interface StudentRepository {
   void saveStudentCourse(StudentCourse studentCourse);
 
   @Update(
-      "UPDATE students SET full_name = #{fullName}, furigana_name = #{furiganaName}, nick_name = #{nickName}, phone_number = #{phoneNumber}, mail_address = #{mailAddress}, municipality_name = #{municipalityName}, age = #{age}, sex = #{sex}, occupation = #{occupation}, remark = #{remark} WHERE student_id = #{studentId}")
+      "UPDATE students SET full_name = #{fullName}, furigana_name = #{furiganaName}, nick_name = #{nickName}, phone_number = #{phoneNumber}, mail_address = #{mailAddress},"
+          + " municipality_name = #{municipalityName}, age = #{age}, sex = #{sex}, occupation = #{occupation}, remark = #{remark}, isDeleted = #{isDeleted} WHERE student_id = #{studentId}")
   void updateStudent(Student student);
 
   @Update(

--- a/src/main/java/raisetech/studentmanagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/studentmanagement/repository/StudentRepository.java
@@ -29,7 +29,7 @@ public interface StudentRepository {
   // 受講生のIDを指定して、1人の学生データを取得
   // students テーブルから、student_id が指定された値と一致するレコードを取得する
   // #{studentId} の部分は、メソッドの引数 studentId の値が埋め込まれる
-  @Select("SELECT * FROM students WHERE student_id = #{studentId}")
+  @Select("SELECT *, isDeleted AS deleted FROM students WHERE student_id = #{studentId}")
   Student findById(String studentId);
 
   // 受講生のIDを指定して、すべてのコース情報を取得
@@ -63,7 +63,7 @@ public interface StudentRepository {
 
   @Update(
       "UPDATE students SET full_name = #{fullName}, furigana_name = #{furiganaName}, nick_name = #{nickName}, phone_number = #{phoneNumber}, mail_address = #{mailAddress},"
-          + " municipality_name = #{municipalityName}, age = #{age}, sex = #{sex}, occupation = #{occupation}, remark = #{remark}, isDeleted = #{isDeleted} WHERE student_id = #{studentId}")
+          + " municipality_name = #{municipalityName}, age = #{age}, sex = #{sex}, occupation = #{occupation}, remark = #{remark}, isDeleted = #{deleted} WHERE student_id = #{studentId}")
   void updateStudent(Student student);
 
   @Update(

--- a/src/main/java/raisetech/studentmanagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/studentmanagement/repository/StudentRepository.java
@@ -20,7 +20,8 @@ public interface StudentRepository {
   //@Selectアノテーションは、このメソッドがSQLのSELECT文を実行することを指定
   //"SELECT * FROM students" は、students テーブルからすべての列と行を取得するSQLクエリ
   //引数なしで呼び出され、すべての学生データをStudentオブジェクトのリストとして返す
-  @Select("SELECT * FROM students")
+  //MyBatisのSQLにカラム名エイリアス(isDeleted AS deleted)を追加。DBのカラム名isDeletedとJavaフィールド名deletedを紐付け
+  @Select("SELECT *, isDeleted AS deleted FROM students")
   List<Student> searchStudents();
 
   @Select("SELECT * FROM students_courses")
@@ -29,6 +30,7 @@ public interface StudentRepository {
   // 受講生のIDを指定して、1人の学生データを取得
   // students テーブルから、student_id が指定された値と一致するレコードを取得する
   // #{studentId} の部分は、メソッドの引数 studentId の値が埋め込まれる
+  // MyBatisのSQLにカラム名エイリアス(isDeleted AS deleted)を追加。DBのカラム名isDeletedとJavaフィールド名deletedを紐付け
   @Select("SELECT *, isDeleted AS deleted FROM students WHERE student_id = #{studentId}")
   Student findById(String studentId);
 

--- a/src/main/java/raisetech/studentmanagement/service/StudentService.java
+++ b/src/main/java/raisetech/studentmanagement/service/StudentService.java
@@ -164,4 +164,12 @@ public class StudentService {
 
     return studentDetail;
   }
+
+  // 削除登録されていない受講生のみを受講生一覧に表示する
+  public List<Student> getNotDeletedStudents() {
+    List<Student> allStudents = repository.searchStudents();
+    return allStudents.stream()
+        .filter(student -> !student.isDeleted())
+        .collect(Collectors.toList());
+  }
 }

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -145,7 +145,11 @@ method="post"： フォームのデータがPOSTメソッドを使ってサー�
              th:name="'studentsCourses[' + ${stat.index} + '].courseExpectedEndDate'"
              th:value="${dates['endDate' + stat.index]}" readonly/>
       <small>（コース開始日の1年後に自動設定されます）</small>
-    </div>
+
+      <div>
+        <label for="isDeleted">削除</label>
+        <input type="checkbox" id="isDeleted" th:field="*{student.deleted}"/>
+      </div>
 
     <!--/*-->
     submitにしておくと、更新ボタンを押したときに/updateStudentsに対して、データを送信することができる

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -152,7 +152,7 @@ method="post"： フォームのデータがPOSTメソッドを使ってサー�
     余白を追加
     <!--*/-->
     <div style="margin-top: 20px;">
-      <button type="submit" style="margin-right: 15px;">登録</button>
+      <button type="submit" style="margin-right: 15px;">更新</button>
       <a th:href="@{/students}">一覧に戻る</a>
     </div>
 </form>


### PR DESCRIPTION
## 【概要】

第30回(受講生情報更新処理の実装)の課題を行いました。

**課題**
受講生情報の削除処理(論理削除)を実装すること
・更新画面で削除登録できるようにする
・削除登録して更新したら、受講生一覧画面には表示されないようにする

ご確認よろしくお願いいたします！

## 【動作確認】
### 受講生更新画面に、削除登録できるようにチェックボックスを作成しました。
![スクリーンショット 2025-03-16 203201](https://github.com/user-attachments/assets/4b900420-6de4-4dfb-92ec-1cf8d1d11446)

### 削除登録した受講生が、一覧から表示されなくなっています。
![スクリーンショット 2025-03-16 203255](https://github.com/user-attachments/assets/f7ac9f33-3611-44cc-81ff-63ebba72ffe9)


### MySQLのデータも変更されています。isDeletedのカラムの表示が0 → 1 になっています。
![スクリーンショット 2025-03-16 203236](https://github.com/user-attachments/assets/b90307fc-74d4-42f0-8a53-98c468fa85a0)
